### PR TITLE
Remove_like_report

### DIFF
--- a/models/comments.js
+++ b/models/comments.js
@@ -9,7 +9,6 @@ const CommentSchema = new Schema(
     reported: { type: Boolean, required: true, default: false },
     published_timestamp: { type: Date, required: true, default: Date.now() },
     parent_post: { type: Schema.Types.ObjectId, ref: 'Post', required: true },
-    likes: { type: Number, required: true, default: 0 },
   },
   { toJSON: { virtuals: true } }
 );

--- a/models/posts.js
+++ b/models/posts.js
@@ -12,7 +12,6 @@ const PostSchema = new Schema(
     updated_timestamp: { type: Date, required: false },
     published_timestamp: { type: Date, required: false },
     comment_array: [{ type: Schema.Types.ObjectId, ref: 'Comment' }],
-    likes: { type: Number, required: true, default: 0 },
   },
   { toJSON: { virtuals: true } }
 );


### PR DESCRIPTION
This PR:
* Removes code that would display/accept input for liking posts/comments and reporting comments
Because:
* Likes and reporting are extra features, and not needed for the project, falling into the 'no-go' zone.

