### PR TITLE
refactor: remove unused v_ props

### DIFF
--- a/models/posts.js
+++ b/models/posts.js
@@ -16,51 +16,9 @@ const PostSchema = new Schema(
   { toJSON: { virtuals: true } }
 );
 
-// virtual for date formatting
-
-PostSchema.virtual('created_timestamp_formatted').get(function () {
-  return this.created_timestamp
-    ? DateTime.fromJSDate(this.created_timestamp).toLocaleString(
-        DateTime.DATE_MED
-      )
-    : '';
-});
-
-PostSchema.virtual('updated_timestamp_formatted').get(function () {
-  return this.updated_timestamp
-    ? DateTime.fromJSDate(this.updated_timestamp).toLocaleString(
-        DateTime.DATE_MED
-      )
-    : '';
-});
-
-PostSchema.virtual('published_timestamp_formatted').get(function () {
-  return this.published_timestamp
-    ? DateTime.fromJSDate(this.published_timestamp).toLocaleString(
-        DateTime.DATE_MED
-      )
-    : '';
-});
-
 // virtual for comment count
 PostSchema.virtual('comment_count').get(function () {
   return this.comment_array ? this.comment_array.length : 0;
-});
-
-// virtual for post age
-
-PostSchema.virtual('post_age_published').get(function () {
-  return this.published_timestamp ? Date.now() - this.published_timestamp : '';
-});
-
-PostSchema.virtual('post_age_created').get(function () {
-  return this.created_timestamp
-    ? +DateTime.fromJSDate(this.created_timestamp)
-        .until(DateTime.now())
-        .toDuration('days')
-        .toObject()
-        .days.toFixed(0)
-    : null;
 });
 
 export default mongoose.model('Post', PostSchema);


### PR DESCRIPTION
This PR:

- removes unused props from the `post` mongoose model

Because:

- not needed